### PR TITLE
Add VPC and two EC2 with security group

### DIFF
--- a/infra/ec2.tf
+++ b/infra/ec2.tf
@@ -46,7 +46,7 @@ module "security_group_dataexfiltration_one" {
       to_port     = -1
       protocol    = "icmp"
       description = "User-service ports"
-      cidr_blocks = "10.0.0.0/24"
+      cidr_blocks = "10.0.0.0/16"
   }]
 }
 
@@ -64,6 +64,6 @@ module "security_group_dataexfiltration_two" {
       to_port     = -1
       protocol    = "icmp"
       description = "User-service ports"
-      cidr_blocks = "10.0.0.0/24"
+      cidr_blocks = "10.0.0.0/16"
   }]
 }

--- a/infra/ec2.tf
+++ b/infra/ec2.tf
@@ -1,5 +1,6 @@
 module "ec2_instance_dataexfiltration" {
-  source = "terraform-aws-modules/ec2-instance/aws"
+  source  = "terraform-aws-modules/ec2-instance/aws"
+  version = "5.7.0"
 
   name = "ec2-${var.prefix}-one"
 
@@ -18,7 +19,8 @@ module "ec2_instance_dataexfiltration" {
 }
 
 module "ec2_instance_dataexfiltration_two" {
-  source = "terraform-aws-modules/ec2-instance/aws"
+  source  = "terraform-aws-modules/ec2-instance/aws"
+  version = "5.7.0"
 
   name = "ec2-${var.prefix}-two"
 

--- a/infra/ec2.tf
+++ b/infra/ec2.tf
@@ -1,0 +1,67 @@
+module "ec2_instance_dataexfiltration" {
+  source = "terraform-aws-modules/ec2-instance/aws"
+
+  name = "ec2-${var.prefix}-one"
+
+  instance_type = "t3.micro"
+  ami           = "ami-06d4fa1e7c1b6d9b7"
+
+  subnet_id              = element(module.vpc_dataexfiltration.private_subnets, 0)
+  vpc_security_group_ids = [module.security_group_dataexfiltration_one.security_group_id]
+
+  create_iam_instance_profile = true
+  iam_role_description        = "IAM role for first EC2 instance"
+  iam_role_use_name_prefix    = true
+  iam_role_policies = {
+    AmazonSSMManagedInstanceCore = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+  }
+}
+
+module "ec2_instance_dataexfiltration_two" {
+  source = "terraform-aws-modules/ec2-instance/aws"
+
+  name = "ec2-${var.prefix}-two"
+
+  instance_type = "t3.micro"
+  ami           = "ami-06d4fa1e7c1b6d9b7"
+
+  subnet_id              = element(module.vpc_dataexfiltration.public_subnets, 0)
+  vpc_security_group_ids = [module.security_group_dataexfiltration_two.security_group_id]
+
+}
+
+module "security_group_dataexfiltration_one" {
+  source  = "terraform-aws-modules/security-group/aws"
+  version = "~> 5.0"
+
+  name         = "${var.prefix}-ec2-one"
+  description  = "Security Group for EC2 Instance Egress"
+  vpc_id       = module.vpc_dataexfiltration.vpc_id
+  egress_rules = ["https-443-tcp"]
+  egress_with_cidr_blocks = [
+    {
+      from_port   = -1
+      to_port     = -1
+      protocol    = "icmp"
+      description = "User-service ports"
+      cidr_blocks = "10.0.0.0/24"
+  }]
+}
+
+module "security_group_dataexfiltration_two" {
+  source  = "terraform-aws-modules/security-group/aws"
+  version = "~> 5.0"
+
+  name        = "${var.prefix}-ec2-two"
+  description = "Security Group for second EC2 Instance Egress"
+  vpc_id      = module.vpc_dataexfiltration.vpc_id
+
+  ingress_with_cidr_blocks = [
+    {
+      from_port   = -1
+      to_port     = -1
+      protocol    = "icmp"
+      description = "User-service ports"
+      cidr_blocks = "10.0.0.0/24"
+  }]
+}

--- a/infra/ec2.tf
+++ b/infra/ec2.tf
@@ -1,4 +1,4 @@
-module "ec2_instance_dataexfiltration" {
+module "ec2_instance_dataexfiltration_one" {
   source = "terraform-aws-modules/ec2-instance/aws"
 
   name = "ec2-${var.prefix}-one"

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "1.9.0"
+  required_version = "1.9.6"
 
   required_providers {
     aws = {

--- a/infra/vpc.tf
+++ b/infra/vpc.tf
@@ -1,0 +1,73 @@
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
+module "vpc_dataexfiltration" {
+  source                       = "terraform-aws-modules/vpc/aws"
+  version                      = "5.1.2"
+  name                         = var.prefix
+  cidr                         = "10.0.0.0/24"
+  azs                          = data.aws_availability_zones.available.names
+  private_subnets              = ["10.0.0.0/26", "10.0.0.64/26"]
+  private_subnet_names         = ["${var.prefix}_private_1", "${var.prefix}_private_2"]
+  public_subnets               = ["10.0.0.128/26", "10.0.0.192/26"]
+  public_subnet_names          = ["${var.prefix}_public_1", "${var.prefix}_public_2"]
+  public_dedicated_network_acl = true
+  enable_nat_gateway           = true
+  single_nat_gateway           = true
+  enable_dns_hostnames         = true
+  enable_dns_support           = true
+}
+
+module "vpc_endpoints_dataexfiltration" {
+  source  = "terraform-aws-modules/vpc/aws//modules/vpc-endpoints"
+  version = "~> 5.0"
+
+  vpc_id = module.vpc_dataexfiltration.vpc_id
+
+  endpoints = { for service in toset(["ssm", "ssmmessages", "ec2messages"]) :
+    replace(service, ".", "_") =>
+    {
+      service             = service
+      subnet_ids          = module.vpc_dataexfiltration.private_subnets
+      private_dns_enabled = true
+    }
+  }
+
+  create_security_group      = true
+  security_group_name_prefix = "vpc-endpoints-${var.prefix}"
+  security_group_description = "VPC endpoint security group"
+  security_group_rules = {
+    ingress_https = {
+      description = "HTTPS from subnets"
+      cidr_blocks = module.vpc_dataexfiltration.private_subnets_cidr_blocks
+    }
+  }
+}
+
+module "vpc_endpoints" {
+  source  = "terraform-aws-modules/vpc/aws//modules/vpc-endpoints"
+  version = "5.13.0"
+
+  vpc_id = module.vpc_dataexfiltration.vpc_id
+
+  create_security_group      = true
+  security_group_name_prefix = "${var.prefix}-vpc-endpoints-"
+  security_group_description = "VPC endpoint security group"
+  security_group_rules = {
+    ingress_https = {
+      description = "HTTPS from VPC"
+      cidr_blocks = [module.vpc_dataexfiltration.vpc_cidr_block]
+    }
+  }
+
+  endpoints = {
+    s3 = {
+      service             = "s3"
+      private_dns_enabled = true
+      dns_options = {
+        private_dns_only_for_inbound_resolver_endpoint = false
+      }
+    }
+  }
+}

--- a/infra/vpc.tf
+++ b/infra/vpc.tf
@@ -6,12 +6,12 @@ module "vpc_dataexfiltration" {
   source                       = "terraform-aws-modules/vpc/aws"
   version                      = "5.1.2"
   name                         = var.prefix
-  cidr                         = "10.0.0.0/24"
+  cidr                         = "10.0.0.0/16"
   azs                          = data.aws_availability_zones.available.names
-  private_subnets              = ["10.0.0.0/26", "10.0.0.64/26"]
-  private_subnet_names         = ["${var.prefix}_private_1", "${var.prefix}_private_2"]
-  public_subnets               = ["10.0.0.128/26", "10.0.0.192/26"]
-  public_subnet_names          = ["${var.prefix}_public_1", "${var.prefix}_public_2"]
+  private_subnets              = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
+  private_subnet_names         = ["${var.prefix}_private_1", "${var.prefix}_private_2", "${var.prefix}_private_3"]
+  public_subnets               = ["10.0.101.0/24", "10.0.102.0/24", "10.0.103.0/24"]
+  public_subnet_names          = ["${var.prefix}_public_1", "${var.prefix}_public_2", "${var.prefix}_public_3"]
   public_dedicated_network_acl = true
   enable_nat_gateway           = true
   single_nat_gateway           = true


### PR DESCRIPTION
Added the following resources:
- single VPC with two different network, public (but not have a public access) and private.
- VPC EndPoint for S3/BynamoDB
- two EC2 istances, first EC2 in public network and second EC2 in private network
- two security group that allow ping from EC2_one to EC2_two and the connection via Session Manager to EC2_one